### PR TITLE
PoW Inscribe

### DIFF
--- a/src/helpers/builders.rs
+++ b/src/helpers/builders.rs
@@ -212,10 +212,10 @@ pub fn create_inscription_transactions(
         );
 
         reveal_tx.output[0].value = reveal_tx.output[0]
-        .value
-        .checked_sub(fee.to_sat())
-        .context("commit transaction output value insufficient to pay transaction fee")
-        .unwrap();
+            .value
+            .checked_sub(fee.to_sat())
+            .context("commit transaction output value insufficient to pay transaction fee")
+            .unwrap();
 
         if reveal_tx.output[0].value < reveal_tx.output[0].script_pubkey.dust_value().to_sat() {
             return Err(anyhow::anyhow!(

--- a/src/helpers/builders.rs
+++ b/src/helpers/builders.rs
@@ -23,7 +23,7 @@ use bitcoin::{
 };
 use ord::{FeeRate, SatPoint, TransactionBuilder};
 
-use crate::helpers::{BODY_TAG, PUBLICKEY_TAG, ROLLUP_NAME_TAG, SIGNATURE_TAG, RANDOM_TAG};
+use crate::helpers::{BODY_TAG, PUBLICKEY_TAG, RANDOM_TAG, ROLLUP_NAME_TAG, SIGNATURE_TAG};
 use crate::spec::utxo::UTXO;
 
 pub fn get_satpoint_to_inscribe(utxo: &UTXO) -> SatPoint {
@@ -116,7 +116,7 @@ pub fn create_inscription_transactions(
         );
     }
 
-    // create inscription content
+    // start creating inscription content
     let reveal_script_builder = script::Builder::new()
         .push_slice(public_key.serialize())
         .push_opcode(OP_CHECKSIG)
@@ -129,46 +129,50 @@ pub fn create_inscription_transactions(
         .push_slice(PushBytesBuf::try_from(PUBLICKEY_TAG.to_vec()).unwrap())
         .push_slice(PushBytesBuf::try_from(sequencer_public_key).unwrap())
         .push_slice(PushBytesBuf::try_from(RANDOM_TAG.to_vec()).unwrap());
+    // This envelope is not finished yet. The random number will be added later and followed by the body
 
+    // Start loop to find a random number that makes the first two bytes of the reveal tx hash 0
     let mut random: i64 = 0;
-    let (
-        unsigned_commit_tx,
-        mut reveal_tx,
-        fee,
-        reveal_script,
-        control_block,
-        taproot_spend_info,
-        commit_tx_address,
-    ) = loop {
+    loop {
         println!("Random: {:?}", random);
 
+        // ownerships are moved to the loop
         let mut reveal_script_builder = reveal_script_builder.clone();
         let change = change.clone();
         let amounts = amounts.clone();
 
+        // push first random number and body tag
         reveal_script_builder = reveal_script_builder
             .push_int(random)
             .push_slice(PushBytesBuf::try_from(BODY_TAG.to_vec()).unwrap());
+
+        // push body in chunks of 520 bytes
         for chunk in body.chunks(520) {
             reveal_script_builder =
                 reveal_script_builder.push_slice(PushBytesBuf::try_from(chunk.to_vec()).unwrap());
         }
+        // push end if
         reveal_script_builder = reveal_script_builder.push_opcode(OP_ENDIF);
 
+        // finalize reveal script
         let reveal_script = reveal_script_builder.into_script();
 
+        // create spend info for tapscript
         let taproot_spend_info = TaprootBuilder::new()
             .add_leaf(0, reveal_script.clone())
             .unwrap()
             .finalize(&secp256k1, public_key)
             .unwrap();
 
+        // create control block for tapscript
         let control_block = taproot_spend_info
             .control_block(&(reveal_script.clone(), LeafVersion::TapScript))
             .unwrap();
 
+        // create commit tx address
         let commit_tx_address = Address::p2tr_tweaked(taproot_spend_info.output_key(), network);
 
+        // create reveal tx to arrange fee
         let (_, reveal_fee) = build_reveal_transaction(
             &control_block,
             reveal_fee_rate,
@@ -180,6 +184,7 @@ pub fn create_inscription_transactions(
             &reveal_script,
         );
 
+        // build commit tx
         let unsigned_commit_tx = TransactionBuilder::build_transaction_with_value(
             satpoint,
             BTreeMap::new(),
@@ -191,7 +196,10 @@ pub fn create_inscription_transactions(
         )
         .unwrap();
 
-        let (reveal_tx, fee) = build_reveal_transaction(
+        let output_to_reveal = unsigned_commit_tx.output[0].clone();
+
+        // build reveal tx
+        let (mut reveal_tx, fee) = build_reveal_transaction(
             &control_block,
             reveal_fee_rate,
             OutPoint {
@@ -200,7 +208,7 @@ pub fn create_inscription_transactions(
             },
             TxOut {
                 script_pubkey: destination.clone().script_pubkey(),
-                value: unsigned_commit_tx.output[0].value,
+                value: output_to_reveal.value,
             },
             &reveal_script,
         );
@@ -209,67 +217,61 @@ pub fn create_inscription_transactions(
 
         // check if first two bytes are 0
         if reveal_hash.starts_with(&[0, 0]) {
-            break (
-                unsigned_commit_tx,
-                reveal_tx,
-                fee,
-                reveal_script,
-                control_block,
-                taproot_spend_info,
-                commit_tx_address,
+            reveal_tx.output[0].value = reveal_tx.output[0]
+                .value
+                .checked_sub(fee.to_sat())
+                .context("commit transaction output value insufficient to pay transaction fee")
+                .unwrap();
+
+            if reveal_tx.output[0].value < reveal_tx.output[0].script_pubkey.dust_value().to_sat() {
+                return Err(anyhow::anyhow!(
+                    "commit transaction output would be dust".to_string()
+                ));
+            }
+
+            // start signing reveal tx
+            let mut sighash_cache = SighashCache::new(&mut reveal_tx);
+
+            // create data to sign
+            let signature_hash = sighash_cache
+                .taproot_script_spend_signature_hash(
+                    0,
+                    &Prevouts::All(&[output_to_reveal]),
+                    TapLeafHash::from_script(&reveal_script, LeafVersion::TapScript),
+                    bitcoin::sighash::TapSighashType::Default,
+                )
+                .unwrap();
+
+            // sign reveal tx data
+            let signature = secp256k1.sign_schnorr(
+                &secp256k1::Message::from_slice(signature_hash.as_byte_array())
+                    .expect("should be cryptographically secure hash"),
+                &key_pair,
             );
-        } 
-        
+
+            // add signature to witness and finalize reveal tx
+            let witness = sighash_cache.witness_mut(0).unwrap();
+            witness.push(signature.as_ref());
+            witness.push(reveal_script);
+            witness.push(&control_block.serialize());
+
+            // check if inscription locked to the correct address
+            let recovery_key_pair =
+                key_pair.tap_tweak(&secp256k1, taproot_spend_info.merkle_root());
+            let (x_only_pub_key, _parity) = recovery_key_pair.to_inner().x_only_public_key();
+            assert_eq!(
+                Address::p2tr_tweaked(
+                    TweakedPublicKey::dangerous_assume_tweaked(x_only_pub_key),
+                    network,
+                ),
+                commit_tx_address
+            );
+
+            return Ok((unsigned_commit_tx, reveal_tx));
+        }
+
         random += 1;
-        println!("Current first two bytes: {:?}", reveal_hash);
-    };
-    
-    reveal_tx.output[0].value = reveal_tx.output[0]
-        .value
-        .checked_sub(fee.to_sat())
-        .context("commit transaction output value insufficient to pay transaction fee")
-        .unwrap();
-
-    if reveal_tx.output[0].value < reveal_tx.output[0].script_pubkey.dust_value().to_sat() {
-        return Err(anyhow::anyhow!(
-            "commit transaction output would be dust".to_string()
-        ));
     }
-
-    let mut sighash_cache = SighashCache::new(&mut reveal_tx);
-
-    let signature_hash = sighash_cache
-        .taproot_script_spend_signature_hash(
-            0,
-            &Prevouts::All(&[unsigned_commit_tx.output[0].clone()]),
-            TapLeafHash::from_script(&reveal_script, LeafVersion::TapScript),
-            bitcoin::sighash::TapSighashType::Default,
-        )
-        .unwrap();
-
-    let signature = secp256k1.sign_schnorr(
-        &secp256k1::Message::from_slice(signature_hash.as_byte_array())
-            .expect("should be cryptographically secure hash"),
-        &key_pair,
-    );
-
-    let witness = sighash_cache.witness_mut(0).unwrap();
-    witness.push(signature.as_ref());
-    witness.push(reveal_script);
-    witness.push(&control_block.serialize());
-
-    let recovery_key_pair = key_pair.tap_tweak(&secp256k1, taproot_spend_info.merkle_root());
-
-    let (x_only_pub_key, _parity) = recovery_key_pair.to_inner().x_only_public_key();
-    assert_eq!(
-        Address::p2tr_tweaked(
-            TweakedPublicKey::dangerous_assume_tweaked(x_only_pub_key),
-            network,
-        ),
-        commit_tx_address
-    );
-
-    Ok((unsigned_commit_tx, reveal_tx))
 }
 
 pub fn write_reveal_tx(tx: &[u8], tx_id: String) {

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -2,6 +2,7 @@
 const ROLLUP_NAME_TAG: &[u8] = &[1];
 const SIGNATURE_TAG: &[u8] = &[2];
 const PUBLICKEY_TAG: &[u8] = &[3];
+const RANDOM_TAG: &[u8] = &[4];
 const BODY_TAG: &[u8] = &[];
 
 pub mod builders;

--- a/src/helpers/parsers.rs
+++ b/src/helpers/parsers.rs
@@ -4,11 +4,10 @@ use bitcoin::blockdata::opcodes::all::{OP_ENDIF, OP_IF};
 use bitcoin::blockdata::script::{Instruction, Instructions};
 use bitcoin::hashes::sha256d;
 use bitcoin::secp256k1::{self, ecdsa, Message, Secp256k1};
-use bitcoin::taproot::TAPROOT_ANNEX_PREFIX;
 use bitcoin::{Script, Transaction};
 use serde::{Deserialize, Serialize};
 
-use super::{BODY_TAG, PUBLICKEY_TAG, ROLLUP_NAME_TAG, SIGNATURE_TAG};
+use super::{BODY_TAG, PUBLICKEY_TAG, ROLLUP_NAME_TAG, SIGNATURE_TAG, RANDOM_TAG};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ParsedInscription {
@@ -25,30 +24,7 @@ pub fn parse_transaction(tx: &Transaction, rollup_name: &str) -> Result<ParsedIn
 
 // Returns the script from the first input of the transaction
 fn get_script(tx: &Transaction) -> Result<&Script, ()> {
-    if tx.input[0].witness.len() > 1 {
-        let witness = &tx.input[0].witness;
-
-        let annex = witness
-            .last()
-            .and_then(|element| element.first().map(|byte| *byte == TAPROOT_ANNEX_PREFIX))
-            .unwrap_or(false);
-
-        let script = tx.input[0]
-            .witness
-            .iter()
-            .nth(if annex {
-                witness.len() - 1
-            } else {
-                witness.len() - 2
-            })
-            .unwrap();
-
-        let script = Script::from_bytes(script);
-
-        Ok(script)
-    } else {
-        Err(())
-    }
+    Ok(tx.input[0].witness.tapscript().ok_or(())?)
 }
 
 // Parses the inscription from script if it is relevant to the rollup
@@ -76,20 +52,18 @@ fn parse_relevant_inscriptions(
             continue;
         }
 
-        let _bytes = match instructions.next() {
+        match instructions.next() {
             Some(Ok(Instruction::PushBytes(bytes))) if bytes.as_bytes() == ROLLUP_NAME_TAG => bytes,
             _ => continue,
         };
 
         let rollup_name_bytes = rollup_name.as_bytes();
-        let _bytes = match instructions.next() {
-            Some(Ok(Instruction::PushBytes(bytes))) if bytes.as_bytes() == rollup_name_bytes => {
-                bytes
-            }
+        match instructions.next() {
+            Some(Ok(Instruction::PushBytes(bytes))) if bytes.as_bytes() == rollup_name_bytes => bytes,
             _ => continue,
         };
 
-        let _bytes = match instructions.next() {
+        match instructions.next() {
             Some(Ok(Instruction::PushBytes(bytes))) if bytes.as_bytes() == SIGNATURE_TAG => bytes,
             _ => continue,
         };
@@ -100,7 +74,7 @@ fn parse_relevant_inscriptions(
         };
         // Found signature
 
-        let _bytes = match instructions.next() {
+        match instructions.next() {
             Some(Ok(Instruction::PushBytes(bytes))) if bytes.as_bytes() == PUBLICKEY_TAG => bytes,
             _ => continue,
         };
@@ -111,7 +85,18 @@ fn parse_relevant_inscriptions(
         };
         // Found public key
 
-        let _bytes = match instructions.next() {
+        match instructions.next() {
+            Some(Ok(Instruction::PushBytes(bytes))) if bytes.as_bytes() == RANDOM_TAG => bytes,
+            _ => continue,
+        };
+
+        match instructions.next() {
+            Some(Ok(Instruction::PushBytes(bytes))) => bytes.as_bytes(),
+            _ => continue,
+        };
+        // Found random
+
+        match instructions.next() {
             Some(Ok(Instruction::PushBytes(bytes))) if bytes.as_bytes() == BODY_TAG => bytes,
             _ => continue,
         };

--- a/src/helpers/parsers.rs
+++ b/src/helpers/parsers.rs
@@ -7,7 +7,7 @@ use bitcoin::secp256k1::{self, ecdsa, Message, Secp256k1};
 use bitcoin::{Script, Transaction};
 use serde::{Deserialize, Serialize};
 
-use super::{BODY_TAG, PUBLICKEY_TAG, ROLLUP_NAME_TAG, SIGNATURE_TAG, RANDOM_TAG};
+use super::{BODY_TAG, PUBLICKEY_TAG, RANDOM_TAG, ROLLUP_NAME_TAG, SIGNATURE_TAG};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ParsedInscription {
@@ -24,7 +24,7 @@ pub fn parse_transaction(tx: &Transaction, rollup_name: &str) -> Result<ParsedIn
 
 // Returns the script from the first input of the transaction
 fn get_script(tx: &Transaction) -> Result<&Script, ()> {
-    Ok(tx.input[0].witness.tapscript().ok_or(())?)
+    tx.input[0].witness.tapscript().ok_or(())
 }
 
 // Parses the inscription from script if it is relevant to the rollup
@@ -59,7 +59,9 @@ fn parse_relevant_inscriptions(
 
         let rollup_name_bytes = rollup_name.as_bytes();
         match instructions.next() {
-            Some(Ok(Instruction::PushBytes(bytes))) if bytes.as_bytes() == rollup_name_bytes => bytes,
+            Some(Ok(Instruction::PushBytes(bytes))) if bytes.as_bytes() == rollup_name_bytes => {
+                bytes
+            }
             _ => continue,
         };
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -464,7 +464,7 @@ mod tests {
             assert_eq!(tx_hash[0..2], [0, 0]);
 
             // it must parsed correctly
-            let parsed_tx = parse_transaction(&tx, &da_service.rollup_name);
+            let parsed_tx = parse_transaction(tx, &da_service.rollup_name);
             if parsed_tx.is_ok() {
                 // it must be in txs
                 assert!(txs_to_check.contains(&tx_hash));

--- a/src/service.rs
+++ b/src/service.rs
@@ -223,7 +223,7 @@ impl DaService for BitcoinService {
 
                 // if tx_hash has two leading zeros, it is in the completeness proof
                 if tx_hash[0..2] == [0, 0] {
-                    completeness_proof.push(tx.clone());
+                    completeness_proof.push(tx.transaction.clone());
                 }
 
                 tx_hash
@@ -348,7 +348,7 @@ mod tests {
             node_username: "chainway".to_string(),
             node_password: "topsecret".to_string(),
             network: Some("regtest".to_string()),
-            address: Some("bcrt1qyxexhcc7vcgvzlg5dncqg383frkeawp39eag4k".to_string()),
+            address: Some("bcrt1qxuds94z3pqwqea2p4f4ev4f25s6uu7y3avljrl".to_string()),
             sequencer_da_private_key: Some(
                 "E9873D79C6D87DC0FB6A5778633389F4453213303DA61F20BD67FC233AA33262".to_string(), // Test key, safe to publish
             ),
@@ -367,7 +367,7 @@ mod tests {
         let da_service = get_service().await;
 
         da_service
-            .get_finalized_at(131)
+            .get_finalized_at(132)
             .await
             .expect("Failed to get block");
     }
@@ -377,7 +377,7 @@ mod tests {
         let da_service = get_service().await;
 
         da_service
-            .get_block_at(131)
+            .get_block_at(132)
             .await
             .expect("Failed to get block");
     }
@@ -387,7 +387,7 @@ mod tests {
         let da_service = get_service().await;
 
         let block = da_service
-            .get_block_at(1009)
+            .get_block_at(132)
             .await
             .expect("Failed to get block");
         // panic!();
@@ -404,7 +404,7 @@ mod tests {
         let da_service = get_service().await;
 
         let block = da_service
-            .get_block_at(1009)
+            .get_block_at(132)
             .await
             .expect("Failed to get block");
 
@@ -458,13 +458,13 @@ mod tests {
             .collect::<std::collections::HashSet<_>>();
 
         completeness_proof.iter().for_each(|tx| {
-            let tx_hash = tx.transaction.txid().to_raw_hash().to_byte_array();
+            let tx_hash = tx.txid().to_raw_hash().to_byte_array();
 
             // it must have two leading zeros in the hash
             assert_eq!(tx_hash[0..2], [0, 0]);
 
             // it must parsed correctly
-            let parsed_tx = parse_transaction(&tx.transaction, &da_service.rollup_name);
+            let parsed_tx = parse_transaction(&tx, &da_service.rollup_name);
             if parsed_tx.is_ok() {
                 // it must be in txs
                 assert!(txs_to_check.contains(&tx_hash));

--- a/src/spec/mod.rs
+++ b/src/spec/mod.rs
@@ -1,3 +1,4 @@
+use bitcoin::Transaction;
 use sov_rollup_interface::da::DaSpec;
 
 use self::blob::BlobWithSender;
@@ -35,7 +36,7 @@ impl DaSpec for BitcoinSpec {
     type InclusionMultiProof = InclusionMultiProof;
 
     // Issue: https://github.com/chainwayxyz/bitcoin-da/issues/2
-    type CompletenessProof = Vec<ExtendedTransaction>;
+    type CompletenessProof = Vec<Transaction>;
 
     type ValidityCondition = ChainValidityCondition;
 }

--- a/src/spec/mod.rs
+++ b/src/spec/mod.rs
@@ -5,7 +5,7 @@ use self::blob::BlobWithSender;
 use self::block_hash::BlockHashWrapper;
 use self::header::HeaderWrapper;
 use self::proof::InclusionMultiProof;
-use self::transaction::ExtendedTransaction;
+
 use crate::verifier::ChainValidityCondition;
 
 pub mod address;

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -128,13 +128,13 @@ impl DaVerifier for BitcoinVerifier {
             .collect::<std::collections::HashSet<_>>();
 
         completeness_proof.iter().for_each(|tx| {
-            let tx_hash = tx.transaction.txid().to_raw_hash().to_byte_array();
+            let tx_hash = tx.txid().to_raw_hash().to_byte_array();
 
             // it must have two leading zeros in the hash
             assert_eq!(tx_hash[0..2], [0, 0]);
 
             // it must parsed correctly
-            let parsed_tx = parse_transaction(&tx.transaction, &self.rollup_name);
+            let parsed_tx = parse_transaction(&tx, &self.rollup_name);
             if parsed_tx.is_ok() {
                 // it must be in txs
                 assert!(txs_to_check.contains(&tx_hash));

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -134,7 +134,7 @@ impl DaVerifier for BitcoinVerifier {
             assert_eq!(tx_hash[0..2], [0, 0]);
 
             // it must parsed correctly
-            let parsed_tx = parse_transaction(&tx, &self.rollup_name);
+            let parsed_tx = parse_transaction(tx, &self.rollup_name);
             if parsed_tx.is_ok() {
                 // it must be in txs
                 assert!(txs_to_check.contains(&tx_hash));


### PR DESCRIPTION
This PR introduces mini PoW mechanism on inscribing blobs. Builder function now adds another tag and bytes to envelope: `RANDOM_TAG` and `a random integer`. Builder tries nonces from 0 until reveal transaction hash starts with 00.

This process simplifies completeness proof:
* Thanks to mini PoW, we do not have to open up each script in block, we can just open up transactions that starts with 00.