### PR TITLE
Use Decompression in Verifier

### DIFF
--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -9,7 +9,7 @@ use sov_rollup_interface::digest::Digest;
 use sov_rollup_interface::zk::ValidityCondition;
 use thiserror::Error;
 
-use crate::helpers::builders::{compress_blob, decompress_blob};
+use crate::helpers::builders::decompress_blob;
 use crate::helpers::parsers::parse_transaction;
 use crate::spec::BitcoinSpec;
 


### PR DESCRIPTION
Decompression is less CPU heavy and performed well on Risc0 benchmark. It is better to use instead compressing