### PR TITLE
check wallets on service creation

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -75,6 +75,7 @@ impl BitcoinNode {
         }
     }
 
+    // TODO: add max retries
     #[async_recursion]
     async fn call<T: serde::de::DeserializeOwned>(
         &self,
@@ -232,6 +233,10 @@ impl BitcoinNode {
             .await
     }
 
+    pub async fn list_wallets(&self) -> Result<Vec<String>, anyhow::Error> {
+        self.call::<Vec<String>>("listwallets", vec![]).await
+    }
+
     #[cfg(test)]
     pub async fn generate_to_address(
         &self,
@@ -271,6 +276,17 @@ mod tests {
 
         utxos.iter().for_each(|utxo| {
             println!("address: {}, amount: {}", utxo.address, utxo.amount);
+        });
+    }
+
+    #[tokio::test]
+    async fn list_wallets() {
+        let node = get_bitcoin_node();
+
+        let wallets = node.list_wallets().await.unwrap();
+
+        wallets.iter().for_each(|wallet| {
+            println!("wallet: {}", wallet);
         });
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -64,7 +64,7 @@ const POLLING_INTERVAL: u64 = 10; // seconds
 
 impl BitcoinService {
     // Create a new instance of the DA service from the given configuration.
-    pub fn new(config: DaServiceConfig, chain_params: RollupParams) -> Self {
+    pub async fn new(config: DaServiceConfig, chain_params: RollupParams) -> Self {
         let network =
             bitcoin::Network::from_str(&config.network).expect("Invalid bitcoin network name");
 
@@ -87,10 +87,10 @@ impl BitcoinService {
             network,
             address,
             private_key,
-        )
+        ).await
     }
 
-    pub fn with_client(
+    pub async fn with_client(
         client: BitcoinNode,
         rollup_name: String,
         network: bitcoin::Network,
@@ -102,6 +102,12 @@ impl BitcoinService {
             .clone()
             .require_network(network)
             .expect("Invalid address for network!");
+
+        let wallets = client.list_wallets().await.expect("Failed to list loaded wallets");
+
+        if wallets.len() != 1 {
+            panic!("Expected exactly one loaded wallet, found {}", wallets.len());
+        }
 
         Self {
             client,
@@ -415,7 +421,7 @@ mod tests {
             RollupParams {
                 rollup_name: "sov-btc".to_string(),
             },
-        )
+        ).await
     }
 
     #[tokio::test]


### PR DESCRIPTION
Looks for a single wallet loaded on the Bitcoin node 

Fails if no wallet or more than one wallet is loaded